### PR TITLE
fix: Duplicate groups makes contact crash

### DIFF
--- a/mail-contact/presentation/src/main/kotlin/ch/protonmail/android/mailcontact/presentation/contactdetails/mapper/ContactDetailsUiModelMapper.kt
+++ b/mail-contact/presentation/src/main/kotlin/ch/protonmail/android/mailcontact/presentation/contactdetails/mapper/ContactDetailsUiModelMapper.kt
@@ -140,7 +140,7 @@ class ContactDetailsUiModelMapper @Inject constructor(
         label = this.emailType.firstOrNull()?.toTextUiModel()
             ?: TextUiModel.TextRes(R.string.contact_type_email),
         value = TextUiModel.Text(this.email),
-        badges = this.groups.map { it.toUiModel() }
+        badges = this.groups.distinct().map { it.toUiModel() }
     )
 
     private fun ContactGroup.toUiModel() = ContactDetailsItemBadgeUiModel(

--- a/mail-contact/presentation/src/test/kotlin/ch/protonmail/android/mailcontact/presentation/contactdetails/mapper/ContactDetailsUiModelMapperReproductionTest.kt
+++ b/mail-contact/presentation/src/test/kotlin/ch/protonmail/android/mailcontact/presentation/contactdetails/mapper/ContactDetailsUiModelMapperReproductionTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 Proton Technologies AG
+ * This file is part of Proton Technologies AG and Proton Mail.
+ *
+ * Proton Mail is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Proton Mail is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Proton Mail. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ch.protonmail.android.mailcontact.presentation.contactdetails.mapper
+
+import androidx.compose.ui.graphics.Color
+import arrow.core.right
+import ch.protonmail.android.mailcommon.domain.model.AvatarInformation
+import ch.protonmail.android.mailcommon.presentation.mapper.ColorMapper
+import ch.protonmail.android.mailcontact.domain.model.ContactDetailCard
+import ch.protonmail.android.mailcontact.domain.model.ContactDetailEmail
+import ch.protonmail.android.mailcontact.domain.model.ContactField
+import ch.protonmail.android.mailcontact.domain.model.ContactGroup
+import ch.protonmail.android.mailcontact.domain.model.ExtendedName
+import ch.protonmail.android.mailcontact.presentation.contactdetails.model.ContactDetailsItemBadgeUiModel
+import ch.protonmail.android.testdata.contact.ContactIdTestData
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ContactDetailsUiModelMapperReproductionTest {
+
+    private val colorMapper = mockk<ColorMapper> {
+        every { toColor(any()) } returns Color.Blue.right()
+    }
+
+    private val mapper = ContactDetailsUiModelMapper(colorMapper)
+
+    @Test
+    fun `should deduplicate contact groups when mapping to ui model`() {
+        // Given
+        val group = ContactGroup(name = "group", color = "color")
+        val contactDetailCard = ContactDetailCard(
+            id = ContactIdTestData.contactId1,
+            remoteId = "id",
+            avatarInformation = AvatarInformation(
+                initials = "P",
+                color = "color"
+            ),
+            extendedName = ExtendedName(
+                last = "Mail",
+                first = "Proton"
+            ),
+            fields = listOf(
+                ContactField.Emails(
+                    list = listOf(
+                        ContactDetailEmail(
+                            email = "pm@pm.me",
+                            emailType = emptyList(),
+                            groups = listOf(group, group) // Duplicate group
+                        )
+                    )
+                )
+            )
+        )
+
+        // When
+        val result = mapper.toUiModel(contactDetailCard)
+
+        // Then
+        val emailItem = result.contactDetailsItemGroupUiModels.first().contactDetailsItemUiModels.first()
+        val expectedBadges = listOf(ContactDetailsItemBadgeUiModel(name = "group", color = Color.Blue))
+        assertEquals(expectedBadges, emailItem.badges, "Badges should be deduplicated")
+    }
+}


### PR DESCRIPTION
When some contacts have duplicated groups for the same items, the rendering crashes.

Context, one of my contact has the following (anonymized) VCARD (exported from proton web ui):

```
BEGIN:VCARD
VERSION:4.0
FN;PREF=1:John Doe
FN;PREF=2:John Doe
TEL;PREF=1:+33666666666
TEL;PREF=2:+33999999999
TEL;PREF=3:+33 1 23 45 67 89
N:;;;;
UID:proton-android-3794338e-4fc7-426f-a6c1-8eabaa54e63f
ITEM1.EMAIL;TYPE=home;PREF=1:abcde@gmail.com
ITEM2.EMAIL;PREF=2:abcde@gmail.com
PRODID;VALUE=TEXT:-//ProtonMail//ProtonMail vCard 1.0.0//EN
ITEM1.CATEGORIES:Family
ITEM2.CATEGORIES:Family
ITEM1.CATEGORIES:Family
ITEM2.CATEGORIES:Family
END:VCARD
```

Trying to open the detail view for this contact makes the application crash with the following trace:

```
java.lang.IllegalArgumentException: Key "Family" was already used. If you are using LazyColumn/Row please make sure you provide a unique key for each item.
 at androidx.compose.ui.internal.a.a(Unknown Source:2)
 at androidx.compose.ui.layout.i0.s(Unknown Source:147)
 at ch.protonmail.android.mailcontact.presentation.contactdetails.ui.c.invoke(Unknown Source:332)
 ...
 ```
 
 A support case was open with ID 4403032 to this subject.